### PR TITLE
update docker-compose to pull from bpni registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build-frontend
+FROM --platform=amd64 node:16 as build-frontend
 
 # Set the working directory
 WORKDIR /app
@@ -24,7 +24,7 @@ RUN npm run build
 # Stage 1: Compile and Build angular codebase
 
 # Use official node image as the base image
-FROM node:13 as build
+FROM --platform=amd64 node:13 as build
 
 # Set the working directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 version: '3'
 services:
   bpni:
-    image: bpni:latest
+    image: racefpv/bpni:latest
     container_name: bpni
-    build: . -t bpni:latest
+    build: .
     environment:
       - ENV_NAME=development
-      - BROWSE_INCREMENT=10
-      - DB_URI=mongodb://database:27017/test
+      - BROWSE_INCREMENT=100
+      - DB_URI=mongodb://database:27017/blueprintnotincluded
       - JWT_SECRET=anylongstringhere
-      - CAPTCHA_SITE=YOURCATCHAKEY
+      - CAPTCHA_SITE=localhost
       - CAPTCHA_SECRET=YOURCAPTCHASECRET
     links:
       - "mongodb-bpni:database"


### PR DESCRIPTION
Adds a proper build option for docker-compose for bpni docker image
Enforces amd64 architecture for docker container builds
Pulls bpni container images from racefpv docker repository for docker-compose up
Uses the correct environment vars for dev for docker-compose