### PR TITLE
Update URL on website actions

### DIFF
--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -2,7 +2,6 @@ import { Injectable } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { AuthenticationService } from "./authentification-service";
 import { map } from "rxjs/operators";
-import { ComponentMenuComponent } from "../components/component-menu/component-menu.component";
 import {
   Blueprint,
   IObsBlueprintChange,

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@angular/core";
+import { Location } from "@angular/common";
 import { HttpClient } from "@angular/common/http";
 import { AuthenticationService } from "./authentification-service";
 import { map } from "rxjs/operators";
@@ -46,7 +47,8 @@ export class BlueprintService implements IObsBlueprintChange {
   // TODO camera service does not need to be injected
   constructor(
     private http: HttpClient,
-    private authService: AuthenticationService
+    private authService: AuthenticationService,
+    private location: Location
   ) {
     this.blueprint = new Blueprint();
 
@@ -240,6 +242,7 @@ export class BlueprintService implements IObsBlueprintChange {
 
   // TODO return observable here so we can close the browse window on success?
   openBlueprintFromId(id: string) {
+    this.location.replaceState(`/b/${id}`);
     this.getBlueprint(id).subscribe({
       next: this.handleGetBlueprint.bind(this),
       error: this.handleGetBlueprintError.bind(this),

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -356,6 +356,7 @@ export class BlueprintService implements IObsBlueprintChange {
         map((response: any) => {
           if (response.id) {
             this.id = response.id;
+            this.location.replaceState(`/b/${this.id}`);
           }
           return response;
         })

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -150,7 +150,7 @@ export class BlueprintService implements IObsBlueprintChange {
     this.name = "new blueprint";
     this.reset();
     let newBlueprint = new Blueprint();
-
+    this.location.replaceState("/");
     this.observersBlueprintChanged.map((observer) => {
       observer.blueprintChanged(newBlueprint);
     });


### PR DESCRIPTION
This uses `location.replaceState` to update the URL during interactions which result in major app state change.

1. NEW blueprint clears the url
2. OPEN blurprint from browse updates the url
3. SAVE blueprint updates link to that blueprint
4. UPLOAD clears the url

This makes the "get shareable link" mostly redundant, but until we replace it with a more robust "share" system (eg: copy to clipboard, send to popular apps) I don't think it's hurting anyone to leave it in.