### PR TITLE
Fix postbuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:backend": "tsc -b",
     "build:lib": "tsc -b lib",
     "build:frontend": "(cd frontend && npm run build -- --output-path=../build/app/public/)",
-    "postbuild": "./scripts/copy_assets.sh && ./scripts/copy_lib.sh && ./scripts/copy_views.sh && ./scripts/copy_public.sh && ./scripts/copy_frontend.sh",
+    "postbuild": "./scripts/copy_assets.sh && ./scripts/copy_lib.sh && ./scripts/copy_views.sh && ./scripts/copy_public.sh",
     "serve:prod": "(cd build && node ./app/server.js)",
     "updateBasedOn": "tsc && node ./build/api/batch/update-based-on.js",
     "updatePositionCorrection": "tsc && node ./build/api/batch/update-position-correction.js",


### PR DESCRIPTION
This step was replaced by the output-dir option in the actual frontend:build script.

I forgot to include it because the deploy.Dockerfile does not execute the postbuild steps.

