### PR TITLE
Replace frontend NG_APP_HOST

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,3 @@
 # variable names must be prefixed by NG_APP_
 NG_APP_GA_TRACKING_CODE="G-G1E1JERVJF"
-NG_APP_HOST="http://localhost:4200"
 NG_APP_SENTRY_DSN="https://0d401c30c07e49618111647aa6da4743@o4504868168925184.ingest.sentry.io/4504868173053952"

--- a/frontend/src/app/module-blueprint/services/blueprint-service.ts
+++ b/frontend/src/app/module-blueprint/services/blueprint-service.ts
@@ -21,7 +21,7 @@ import * as yaml from "node_modules/js-yaml/lib/js-yaml";
 
 @Injectable({ providedIn: "root" })
 export class BlueprintService implements IObsBlueprintChange {
-  static baseUrl: string = process.env.NG_APP_HOST;
+  static baseUrl: string = window.location.origin;
 
   id: string;
   name: string;


### PR DESCRIPTION
To avoid multiple builds (now docker images) for each environment we will need a way to pass ENV from the backend to the frontend on page load. But all the internet answers seem awful. I'd like to delay making a choice so I'm going to replace the only really important one with runtime code.