### PR TITLE
Fix unintended tool switch when typing

### DIFF
--- a/frontend/src/app/module-blueprint/common/tools/select-tool.ts
+++ b/frontend/src/app/module-blueprint/common/tools/select-tool.ts
@@ -366,6 +366,13 @@ export class SelectTool implements ITool {
           this.sameItemCollections[itemGroupToDestroyIndex]
         );
     } else if (keyCode == "b") {
+      // ignore keypress when a textbox is active
+      let textboxElements = ["INPUT", "TEXTAREA"];
+      let activeElement = document.activeElement.tagName;
+      if ( textboxElements.includes(activeElement)) {
+        return;
+      }
+
       // find the currently selected item
       let newItem = null;
       let itemGroupToDestroyIndex = this.currentMultipleSelectionIndex;


### PR DESCRIPTION
Resolves issue #1

Bug: Pressing the "b" key erroneously activates the build tool when user is attempting to type into a textbox.

Fix: Ignore "b" key presses when typing into `<textarea>` and `<input>` elements.